### PR TITLE
refactor: migrate from tui to ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,85 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "ahash"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "autocfg"
@@ -21,16 +96,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -40,25 +115,36 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crossbeam"
@@ -120,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -133,7 +219,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -145,11 +231,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -161,21 +247,21 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "ctrlc"
-version = "3.2.5"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -191,25 +277,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "errno"
-version = "0.2.8"
+name = "hashbrown"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -221,18 +302,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
+name = "indoc"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inquire"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a94f0659efe59329832ba0452d3ec753145fc1fb12a8e1d60de4ccf99f5364"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm 0.25.0",
  "dyn-clone",
  "lazy_static",
@@ -243,25 +324,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.5"
+name = "itertools"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
-dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys",
+ "either",
 ]
 
 [[package]]
@@ -282,15 +350,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "lock_api"
@@ -312,6 +374,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,7 +406,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -343,14 +420,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -359,15 +435,15 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
+name = "once_cell"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -389,14 +465,20 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.51"
+name = "paste"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -408,21 +490,39 @@ dependencies = [
  "anyhow",
  "clap",
  "crossbeam-utils",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "ctrlc",
  "inquire",
  "jwalk",
+ "ratatui",
  "regex",
- "tui",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
+dependencies = [
+ "bitflags 2.4.1",
+ "cassowary",
+ "crossterm 0.27.0",
+ "indoc",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -453,37 +553,43 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "rustix"
-version = "0.36.8"
+name = "rustversion"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "scopeguard"
@@ -493,9 +599,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -528,16 +634,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "syn"
@@ -551,12 +673,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "syn"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -576,20 +700,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -609,6 +720,18 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -633,15 +756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +767,25 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -662,13 +794,43 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -678,10 +840,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -690,10 +876,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -702,13 +912,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["command-line-utilities"]
 keywords = ["command-line", "clean", "tui"]
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0.75"
 jwalk = "0.8.1"
-tui = "0.19.0"
-crossterm = "0.26.1"
-crossbeam-utils = "0.8"
-clap = "4.1.8"
-regex = { version = "1.5", features = ["std"], default-features = false }
-ctrlc = "3.2"
-inquire = "0.5.3"
+ratatui = "0.24.0"
+crossterm = "0.27.0"
+crossbeam-utils = "0.8.16"
+clap = "4.4.11"
+regex = { version = "1.10.2", features = ["std"], default-features = false }
+ctrlc = "3.4.1"
+inquire = "0.6.2"
 
 [profile.release]
 lto = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,21 +1,21 @@
 use crate::{human_readable_folder_size, Message, PathItem, PathState};
 
-use anyhow::Result;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers},
-    execute,
+    event::{self, Event, KeyCode, KeyModifiers},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
 };
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Color, Modifier, Style, Stylize},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame, Terminal,
 };
 use std::{
     fs::remove_dir_all,
+    io::stdout,
     path::{Path, PathBuf},
     sync::mpsc::Sender,
     thread,
@@ -37,344 +37,331 @@ const SPINNER_DOTS: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦
 /// title or hint
 const TITLE: &str = "Select with ↑CURSOR↓ and press SPACE key to delete.";
 
-pub fn run(rx: Receiver<Message>, tx: Sender<Message>) -> Result<()> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
-    let app = App::default();
-    let res = run_ui(&mut terminal, tx, rx, app);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    res?;
-
-    Ok(())
-}
-
-fn run_ui<B: Backend>(
-    terminal: &mut Terminal<B>,
-    tx: Sender<Message>,
-    rx: Receiver<Message>,
-    mut app: App,
-) -> io::Result<()> {
-    let tick_rate = Duration::from_millis(TICK_INTERVAL);
-
-    let mut last_tick = Instant::now();
-    loop {
-        terminal.draw(|f| draw(f, &mut app))?;
-
-        if let Ok(item) = rx.try_recv() {
-            match item {
-                Message::AddPath(item) => {
-                    app.total_size += item.size.unwrap_or_default();
-                    app.add_item(item);
-                }
-                Message::DoneSearch => {
-                    app.done_search = true;
-                }
-                Message::SetPathDeleted(path) => {
-                    let size = app.set_item_deleted(path);
-                    app.total_saved_size += size.unwrap_or_default();
-                }
-                Message::PutError(message) => {
-                    app.error = Some(message);
-                }
-            }
-        }
-
-        let timeout = tick_rate
-            .checked_sub(last_tick.elapsed())
-            .unwrap_or_else(|| Duration::from_secs(0));
-
-        if crossterm::event::poll(timeout)? {
-            if let Event::Key(key) = event::read()? {
-                let mut set_last_code = true;
-
-                app.clear_tmp_state();
-
-                match key.code {
-                    KeyCode::Char('q') => return Ok(()),
-                    KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => return Ok(()),
-                    KeyCode::Char('j') | KeyCode::Down => app.next(),
-                    KeyCode::Char('k') | KeyCode::Up => app.previous(),
-                    KeyCode::Char('?') => app.show_help = true,
-                    KeyCode::Home => app.begin(),
-                    KeyCode::Char('G') | KeyCode::End => app.end(),
-                    KeyCode::Char('g') => {
-                        if let Some(KeyCode::Char('g')) = app.last_keycode {
-                            app.begin();
-                            set_last_code = false;
-                        }
-                    }
-                    KeyCode::Char('p') => {
-                        if let Some(KeyCode::Char('o')) = app.last_keycode {
-                            app.order_by_path();
-                            set_last_code = false;
-                        }
-                    }
-                    KeyCode::Char('s') => {
-                        if let Some(KeyCode::Char('o')) = app.last_keycode {
-                            app.order_by_size();
-                            set_last_code = false;
-                        }
-                    }
-                    KeyCode::Char('d') => {
-                        if let Some(KeyCode::Char('d')) = app.last_keycode {
-                            app.delete_item(tx.clone());
-                            set_last_code = false;
-                        }
-                    }
-                    KeyCode::Char('a') => {
-                        if let Some(KeyCode::Char('d')) = app.last_keycode {
-                            app.delete_all_items(tx.clone());
-                            set_last_code = false;
-                        }
-                    }
-                    KeyCode::Char(' ') => {
-                        app.delete_item(tx.clone());
-                        app.last_keycode = None;
-                    }
-                    _ => {}
-                }
-                if set_last_code {
-                    app.last_keycode = Some(key.code);
-                }
-            }
-        }
-
-        if last_tick.elapsed() >= tick_rate {
-            app.on_tick();
-            last_tick = Instant::now();
-        }
-    }
-}
-
-fn draw(f: &mut Frame, app: &mut App) {
-    if app.show_help {
-        draw_help_view(f, f.size());
-        return;
-    }
-
-    let constraints = if app.error.is_some() {
-        vec![
-            Constraint::Min(0),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ]
-    } else {
-        vec![Constraint::Min(0), Constraint::Length(1)]
-    };
-
-    let chunks = Layout::default().constraints(constraints).split(f.size());
-
-    draw_list_view(f, app, chunks[0]);
-    draw_status_bar(f, app, chunks[1]);
-    if let Some(error) = app.error.as_ref() {
-        draw_error_line(f, error, chunks[2])
-    }
-}
-
-fn draw_list_view(f: &mut Frame, app: &mut App, area: Rect) {
-    let width = area.width - 2;
-    let items: Vec<ListItem> = app
-        .items
-        .iter()
-        .enumerate()
-        .map(|(index, item)| {
-            let is_selected = app
-                .state
-                .selected()
-                .map(|selected| selected == index)
-                .unwrap_or_default();
-
-            let mut width = width;
-            width -= (item.size_text.len() + PATH_SEPARATE.len()) as u16;
-            let mut styles = vec![
-                Style::default(),
-                Style::default(),
-                Style::default().fg(Color::DarkGray),
-            ];
-            if is_selected {
-                styles = styles.into_iter().map(|v| v.fg(Color::Cyan)).collect();
-            }
-            let indicator_span = match item.state {
-                PathState::Deleted => {
-                    styles = styles
-                        .into_iter()
-                        .map(|v| v.add_modifier(Modifier::DIM))
-                        .collect();
-                    width -= 3;
-                    Span::styled(" ✘ ", styles[0])
-                }
-                PathState::StartDeleting => {
-                    width -= 3;
-                    Span::styled(format!(" {} ", app.spinner()), styles[0])
-                }
-                _ => Span::styled("", styles[0]),
-            };
-            let path_span = Span::styled(truncate_path(&item.relative_path, width), styles[0]);
-            let separate_span = Span::styled(PATH_SEPARATE, styles[0]);
-            let size_span = Span::styled(item.size_text.clone(), styles[1]);
-            let mut spans = vec![path_span, separate_span, size_span];
-            spans.push(indicator_span);
-            ListItem::new(Line::from(spans))
-        })
-        .collect();
-    let title = Span::styled(TITLE, Style::default().fg(Color::Yellow));
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(Line::from(vec![title])),
-    );
-    f.render_stateful_widget(list, area, &mut app.state);
-}
-
-fn draw_status_bar(f: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(16)].as_ref())
-        .split(area);
-
-    let indicator = if app.done_search {
-        " ✔ ".to_string()
-    } else {
-        format!(" {} ", app.spinner())
-    };
-    let spans = vec![
-        Span::raw(indicator),
-        Span::styled("total space:", Style::default().fg(Color::DarkGray)),
-        Span::raw(format!(" {} ", human_readable_folder_size(app.total_size))),
-        Span::styled("released space:", Style::default().fg(Color::DarkGray)),
-        Span::raw(format!(
-            " {} ",
-            human_readable_folder_size(app.total_saved_size)
-        )),
-    ];
-    let status_text = Paragraph::new(Line::from(spans));
-
-    let spans = vec![Span::styled(
-        "Press ? for help".to_string(),
-        Style::default().fg(Color::DarkGray),
-    )];
-
-    let help_text = Paragraph::new(Line::from(spans));
-
-    f.render_widget(status_text, chunks[0]);
-    f.render_widget(help_text, chunks[1]);
-}
-
-fn draw_error_line(f: &mut Frame, error: &str, area: Rect) {
-    let paragraph = Paragraph::new(Line::from(vec![Span::styled(
-        error.to_string(),
-        Style::default().fg(Color::Red),
-    )]));
-    f.render_widget(paragraph, area);
-}
-
-fn draw_help_view(f: &mut Frame, area: Rect) {
-    let help_docs = vec![
-        ["Move selection up", "k  | <up> "],
-        ["Move selection down", "j  | <down> "],
-        ["Move to the top", "gg | <home> "],
-        ["Move to the bottom", "G  | <end> "],
-        ["Delete selected folder", "dd | <space> "],
-        ["Delete all listed folder", "da"],
-        ["Sort by path", "op"],
-        ["Sort by size", "os"],
-        ["Exit", "q  | <ctrl+c>"],
-    ];
-
-    let items: Vec<ListItem> = help_docs
-        .into_iter()
-        .map(|row| {
-            let [desc, keycode] = row;
-            let desc_style = Style::default();
-            let keycode_style = Style::default();
-            let content = vec![Line::from(vec![
-                Span::styled(format!(" {desc:<30}"), desc_style),
-                Span::styled(keycode.to_string(), keycode_style),
-            ])];
-            ListItem::new(content)
-        })
-        .collect();
-
-    let title = Span::styled(" Help ", Style::default().fg(Color::Yellow));
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(Line::from(vec![title])),
-    );
-    f.render_widget(list, area);
-}
-
 #[derive(Debug, Default)]
 struct App {
-    state: ListState,
+    list_state: ListState,
     items: Vec<PathItem>,
     spinner_index: usize,
     total_size: u64,
     total_saved_size: u64,
-    done_search: bool,
     show_help: bool,
     error: Option<String>,
     last_keycode: Option<KeyCode>,
+    app_state: AppState,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+enum AppState {
+    #[default]
+    Searching,
+    SearchingDone,
+    Exit,
+}
+
+pub fn run(rx: Receiver<Message>, tx: Sender<Message>) -> io::Result<()> {
+    let mut terminal = init_terminal()?;
+    // result is evaluated after restoring terminal to ensure that it does not get printed on the
+    // alternate screen in raw mode
+    let res = App::default().run(&mut terminal, tx, rx);
+    restore_terminal(terminal)?;
+    res
+}
+
+fn init_terminal() -> io::Result<Terminal<impl Backend>> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    Terminal::new(CrosstermBackend::new(stdout()))
+}
+
+fn restore_terminal(mut terminal: Terminal<impl Backend>) -> io::Result<()> {
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
 }
 
 impl App {
+    fn run(
+        mut self,
+        terminal: &mut Terminal<impl Backend>,
+        tx: Sender<Message>,
+        rx: Receiver<Message>,
+    ) -> io::Result<()> {
+        let tick_rate = Duration::from_millis(TICK_INTERVAL);
+        let mut last_tick = Instant::now();
+        while self.app_state != AppState::Exit {
+            terminal.draw(|frame| self.draw(frame))?;
+
+            self.handle_next_message(&rx);
+
+            let timeout = tick_rate
+                .checked_sub(last_tick.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(0));
+
+            self.handle_events(timeout, &tx)?;
+
+            if last_tick.elapsed() >= tick_rate {
+                self.on_tick();
+                last_tick = Instant::now();
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_next_message(&mut self, rx: &Receiver<Message>) {
+        let Ok(item) = rx.try_recv() else { return };
+        match item {
+            Message::AddPath(item) => {
+                self.total_size += item.size.unwrap_or_default();
+                self.add_item(item);
+            }
+            Message::DoneSearch => {
+                self.app_state = AppState::SearchingDone;
+            }
+            Message::SetPathDeleted(path) => {
+                let size = self.set_item_deleted(path);
+                self.total_saved_size += size.unwrap_or_default();
+            }
+            Message::PutError(message) => {
+                self.error = Some(message);
+            }
+        }
+    }
+
+    fn handle_events(&mut self, timeout: Duration, tx: &Sender<Message>) -> Result<(), io::Error> {
+        if crossterm::event::poll(timeout)? {
+            if let Event::Key(key) = event::read()? {
+                self.handle_key_event(key, tx)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_key_event(&mut self, key: event::KeyEvent, tx: &Sender<Message>) -> io::Result<()> {
+        // ignore key release event
+        if key.kind != event::KeyEventKind::Press {
+            return Ok(());
+        }
+        let mut set_last_code = true;
+        self.clear_tmp_state();
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.app_state = AppState::Exit;
+            }
+            KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.app_state = AppState::Exit;
+            }
+            KeyCode::Char('j') | KeyCode::Down => self.next(),
+            KeyCode::Char('k') | KeyCode::Up => self.previous(),
+            KeyCode::Char('?') => self.show_help = true,
+            KeyCode::Home => self.begin(),
+            KeyCode::Char('G') | KeyCode::End => self.end(),
+            KeyCode::Char('g') => {
+                if let Some(KeyCode::Char('g')) = self.last_keycode {
+                    self.begin();
+                    set_last_code = false;
+                }
+            }
+            KeyCode::Char('p') => {
+                if let Some(KeyCode::Char('o')) = self.last_keycode {
+                    self.order_by_path();
+                    set_last_code = false;
+                }
+            }
+            KeyCode::Char('s') => {
+                if let Some(KeyCode::Char('o')) = self.last_keycode {
+                    self.order_by_size();
+                    set_last_code = false;
+                }
+            }
+            KeyCode::Char('d') => {
+                if let Some(KeyCode::Char('d')) = self.last_keycode {
+                    self.delete_item(tx.clone());
+                    set_last_code = false;
+                }
+            }
+            KeyCode::Char('a') => {
+                if let Some(KeyCode::Char('d')) = self.last_keycode {
+                    self.delete_all_items(tx.clone());
+                    set_last_code = false;
+                }
+            }
+            KeyCode::Char(' ') => {
+                self.delete_item(tx.clone());
+                self.last_keycode = None;
+            }
+            _ => {}
+        }
+        if set_last_code {
+            self.last_keycode = Some(key.code);
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        if self.show_help {
+            Self::draw_help_view(frame, frame.size());
+            return;
+        }
+
+        let mut constraints = vec![Constraint::Min(0), Constraint::Length(1)];
+        if self.error.is_some() {
+            constraints.push(Constraint::Length(1));
+        };
+
+        let areas = Layout::default()
+            .constraints(constraints)
+            .split(frame.size());
+
+        self.draw_list_view(frame, areas[0]);
+        self.draw_status_bar(frame, areas[1]);
+        if let Some(error) = self.error.as_ref() {
+            Self::draw_error_line(frame, error, areas[2])
+        }
+    }
+
+    fn draw_list_view(&mut self, frame: &mut Frame, area: Rect) {
+        let items: Vec<ListItem> = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| {
+                let is_selected = self.list_state.selected() == Some(index);
+                let mut width = area.width - 2;
+                width -= (item.size_text.len() + PATH_SEPARATE.len()) as u16;
+                let mut styles = vec![Style::default(), Style::default()];
+                if is_selected {
+                    styles = styles.into_iter().map(|v| v.fg(Color::Cyan)).collect();
+                }
+                let indicator_span = match item.state {
+                    PathState::Deleted => {
+                        styles = styles
+                            .into_iter()
+                            .map(|v| v.add_modifier(Modifier::DIM))
+                            .collect();
+                        width -= 3;
+                        Span::styled(" ✘ ", styles[0])
+                    }
+                    PathState::StartDeleting => {
+                        width -= 3;
+                        Span::styled(format!(" {} ", self.spinner()), styles[0])
+                    }
+                    _ => Span::styled("", styles[0]),
+                };
+                let path_span = Span::styled(truncate_path(&item.relative_path, width), styles[0]);
+                let separate_span = Span::styled(PATH_SEPARATE, styles[0]);
+                let size_span = Span::styled(item.size_text.clone(), styles[1]);
+                let mut spans = vec![path_span, separate_span, size_span];
+                spans.push(indicator_span);
+                ListItem::new(Line::from(spans))
+            })
+            .collect();
+        let title = Span::styled(TITLE, Style::default().fg(Color::Yellow));
+        let list = List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from(vec![title])),
+        );
+        frame.render_stateful_widget(list, area, &mut self.list_state);
+    }
+
+    fn draw_status_bar(&mut self, frame: &mut Frame, area: Rect) {
+        let search_indicator = match self.app_state {
+            AppState::Searching => format!(" {} ", self.spinner()),
+            AppState::SearchingDone => " ✔ ".to_string(),
+            AppState::Exit => " ✘ ".to_string(),
+        };
+
+        let status_line = Line::from(vec![
+            search_indicator.into(),
+            "total space: ".dark_gray(),
+            human_readable_folder_size(self.total_size).into(),
+            " released space:".dark_gray(),
+            human_readable_folder_size(self.total_saved_size).into(),
+            " ".into(),
+        ]);
+
+        let help_line = Line::from(vec![Span::styled(
+            "Press ? for help".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )]);
+
+        let areas = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(0), Constraint::Length(16)])
+            .split(area);
+
+        frame.render_widget(Paragraph::new(status_line), areas[0]);
+        frame.render_widget(Paragraph::new(help_line), areas[1]);
+    }
+
+    fn draw_error_line(frame: &mut Frame, error: &str, area: Rect) {
+        let error_line = error.to_string().red();
+        frame.render_widget(Paragraph::new(error_line), area);
+    }
+
+    fn draw_help_view(frame: &mut Frame, area: Rect) {
+        let help_docs = vec![
+            ("Move selection up", "k  | <up> "),
+            ("Move selection down", "j  | <down> "),
+            ("Move to the top", "gg | <home> "),
+            ("Move to the bottom", "G  | <end> "),
+            ("Delete selected folder", "dd | <space> "),
+            ("Delete all listed folder", "da"),
+            ("Sort by path", "op"),
+            ("Sort by size", "os"),
+            ("Exit", "q  | <ctrl+c>"),
+        ];
+        let items: Vec<ListItem> = help_docs
+            .into_iter()
+            .map(|(desc, keycode)| {
+                ListItem::new(Line::from(vec![
+                    format!(" {desc:<30}").into(),
+                    keycode.into(),
+                ]))
+            })
+            .collect();
+        let title = " Help ".yellow();
+        let list = List::new(items).block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(list, area);
+    }
+}
+
+impl App {
+    /// move selection to next item (with wrap around to the top)
     fn next(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i >= self.items.len().saturating_sub(1) {
-                    0
-                } else {
-                    i + 1
-                }
-            }
-            None => 0,
-        };
-        self.state.select(Some(i));
+        let next = self
+            .list_state
+            .selected()
+            .map(|i| (i + 1) % self.items.len())
+            .or(Some(0));
+        self.list_state.select(next);
     }
 
+    /// select the previous item (with wrap around to the bottom)
     fn previous(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.items.len().saturating_sub(1)
-                } else {
-                    i - 1
-                }
-            }
-            None => 0,
-        };
-        self.state.select(Some(i));
+        let next = self
+            .list_state
+            .selected()
+            .map(|i| (i + self.items.len().saturating_sub(1)) % self.items.len())
+            .or(Some(0));
+        self.list_state.select(next);
     }
 
+    /// move selection to the top
     fn begin(&mut self) {
-        let len = self.items.len();
-        if len == 0 {
-            self.state.select(None);
+        if self.items.len() == 0 {
+            self.list_state.select(None);
         } else {
-            self.state.select(Some(0));
+            self.list_state.select(Some(0));
         }
     }
 
     fn end(&mut self) {
-        let len = self.items.len();
-        if len == 0 {
-            self.state.select(None);
+        if self.items.len() == 0 {
+            self.list_state.select(None);
         } else {
-            self.state.select(Some(len - 1));
+            self.list_state.select(Some(self.items.len() - 1));
         }
     }
 
@@ -408,7 +395,7 @@ impl App {
     }
 
     fn start_deleting_item(&mut self) -> Option<PathBuf> {
-        if let Some(index) = self.state.selected() {
+        if let Some(index) = self.list_state.selected() {
             let item = &mut self.items[index];
             if item.state != PathState::Normal || item.size.is_none() {
                 None

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,8 +151,16 @@ impl App {
             KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
                 self.app_state = AppState::Exit;
             }
-            KeyCode::Char('j') | KeyCode::Down => self.next(),
-            KeyCode::Char('k') | KeyCode::Up => self.previous(),
+            KeyCode::Char('j') | KeyCode::Down => {
+                if key.kind == event::KeyEventKind::Press {
+                    self.next()
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if key.kind == event::KeyEventKind::Press {
+                    self.previous()
+                }
+            }
             KeyCode::Char('?') => self.show_help = true,
             KeyCode::Home => self.begin(),
             KeyCode::Char('G') | KeyCode::End => self.end(),
@@ -350,7 +358,7 @@ impl App {
 
     /// move selection to the top
     fn begin(&mut self) {
-        if self.items.len() == 0 {
+        if self.items.is_empty() {
             self.list_state.select(None);
         } else {
             self.list_state.select(Some(0));
@@ -358,7 +366,7 @@ impl App {
     }
 
     fn end(&mut self) {
-        if self.items.len() == 0 {
+        if self.items.is_empty() {
             self.list_state.select(None);
         } else {
             self.list_state.select(Some(self.items.len() - 1));


### PR DESCRIPTION
Simplify a bunch of methods with more idiomatic Rust code, and patterns
that work well for Ratatui apps.

Includes the Ratatui and other lib updates from #17 

Tested this as working (freed up ~150GB of target folders on my laptop)