### PR TITLE
fix: windows build error + navigate by 2

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -176,9 +176,7 @@ fn draw<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         vec![Constraint::Min(0), Constraint::Length(1)]
     };
 
-    let chunks = Layout::default()
-        .constraints(constraints.as_ref())
-        .split(f.size());
+    let chunks = Layout::default().constraints(constraints).split(f.size());
 
     draw_list_view(f, app, chunks[0]);
     draw_status_bar(f, app, chunks[1]);

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,8 +106,16 @@ fn run_ui<B: Backend>(
                 match key.code {
                     KeyCode::Char('q') => return Ok(()),
                     KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => return Ok(()),
-                    KeyCode::Char('j') | KeyCode::Down => app.next(),
-                    KeyCode::Char('k') | KeyCode::Up => app.previous(),
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if key.kind == event::KeyEventKind::Press {
+                            app.next()
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        if key.kind == event::KeyEventKind::Press {
+                            app.previous()
+                        }
+                    }
                     KeyCode::Char('?') => app.show_help = true,
                     KeyCode::Home => app.begin(),
                     KeyCode::Char('G') | KeyCode::End => app.end(),


### PR DESCRIPTION
I am not sure if either of these are Windows specific so let me know if they (don't) work for you on other platforms.

## Build Error

Running `cargo install` or just `build` results in the following:

```rs
error[E0283]: type annotations needed
   --> src\app.rs:180:10
    |
180 |         .constraints(constraints.as_ref())
    |          ^^^^^^^^^^^             ------ type must be known at this point
    |          |
    |          cannot infer type of the type parameter `C` declared on the method `constraints`
    |
    = note: multiple `impl`s satisfying `Vec<Constraint>: AsRef<_>` found in the `alloc` crate:
            - impl<T, A> AsRef<Vec<T, A>> for Vec<T, A>
              where A: Allocator;
            - impl<T, A> AsRef<[T]> for Vec<T, A>
              where A: Allocator;
help: consider specifying the generic argument
    |
180 |         .constraints::<&T>(constraints.as_ref())
    |                     ++++++

For more information about this error, try `rustc --explain E0283`.
error: could not compile `projclean` (bin "projclean") due to previous error
```

Not sure how this is *not* a problem in other platforms but [it works for me now](https://github.com/sigoden/projclean/commit/068d37e5af8f6abbdf0056972115f214e5ca84f5).

## Navigating by 2

Using the up and down arrow keys causes the menu selection to move twice. This is because key events are fired both on press down and on release. I am again confused about how this was not noticed before which leads me to believe some weird platform-specific business is going on in here perhaps?

In any case, this likely affects other parts of the relevant match case, I didn't make any edits as I won't be using any of the other keys and I don't know if this is just a me problem or not. Let me know if you want me to look into them as well for the sake of the PR.