### PR TITLE
feat: search rule supports multiple detects

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,34 +78,33 @@ Rule consist of two parts:
 <target[,target...]>[@flag]
 ```
 
-| project    | rule                              |
-| :--------- | :-------------------------------- |
-| node       | `node_modules`                    |
-| cargo      | `target@Cargo.toml`               |
-| maven      | `target@pom.xml`                  |
-| gradle     | `.gradle,build@build.gradle`      |
-| gradle-kts | `.gradle,build@build.gradle.kts`  |
-| cmake      | `build@CMakeLists.txt`            |
-| composer   | `vendor@composer.json`            |
-| swift      | `.build,.swiftpm@Package.swift`   |
-| dart       | `.dart_tool,build@pubspec.yaml`   |
-| cocoapods  | `Pods@Podfile`                    |
-| sbt        | `target,project/target@build.sbt` |
-| zig        | `zig-cache,zig-out@build.zig`     |
-| stack      | `.stack-work@stack.yaml`          |
-| jupyter    | `.ipynb_checkpoints@*.ipynb`      |
-| ocaml      | `_build@dune-project`             |
-| elixir     | `_build@mix.exs`                  |
-| erlang     | `_build@rebar.config`             |
-| vs         | `.vs,Debug,Release@*.sln`         |
-| vc         | `Debug,Release@*.vcxproj`         |
-| c#         | `bin,obj@*.csproj`                |
-| f#         | `bin,obj@*.fsproj`                |
-| godot      | `.godot@project.godot`            |
+| project   | rule                                          |
+| :-------- | :-------------------------------------------- |
+| node      | `node_modules`                                |
+| cargo     | `target@Cargo.toml`                           |
+| maven     | `target@pom.xml`                              |
+| gradle    | `.gradle,build@build.gradle,build.gradle.kts` |
+| cmake     | `build@CMakeLists.txt`                        |
+| composer  | `vendor@composer.json`                        |
+| swift     | `.build,.swiftpm@Package.swift`               |
+| dart      | `.dart_tool,build@pubspec.yaml`               |
+| cocoapods | `Pods@Podfile`                                |
+| sbt       | `target,project/target@build.sbt`             |
+| zig       | `zig-cache,zig-out@build.zig`                 |
+| stack     | `.stack-work@stack.yaml`                      |
+| jupyter   | `.ipynb_checkpoints@*.ipynb`                  |
+| ocaml     | `_build@dune-project`                         |
+| elixir    | `_build@mix.exs`                              |
+| erlang    | `_build@rebar.config`                         |
+| vs        | `.vs,Debug,Release@*.sln`                     |
+| vc        | `Debug,Release@*.vcxproj`                     |
+| c#        | `bin,obj@*.csproj`                            |
+| f#        | `bin,obj@*.fsproj`                            |
+| godot     | `.godot@project.godot`                        |
 
 ## License
 
-Copyright (c) 2022-2023 projclean-developers.
+Copyright (c) 2022-2024 projclean-developers.
 
 argc is made available under the terms of either the MIT License or the Apache License 2.0, at your option.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Projclean find targets according search rule.
 Rule consist of two parts:
 
 ```
-<target[,target...]>[@flag]
+<target[,target...]>[@check[,check...]]
 ```
 
 | project   | rule                                          |

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,11 @@ use fs::{delete_all, ls, search};
 use common::{human_readable_folder_size, Config, Message, PathItem, PathState};
 use inquire::{formatter::MultiOptionFormatter, MultiSelect};
 
-const RULES: [(&str, &str); 22] = [
+const RULES: [(&str, &str); 21] = [
     ("node", "node_modules"),
     ("cargo", "target@Cargo.toml"),
     ("maven", "target@pom.xml"),
-    ("gradle", ".gradle,build@build.gradle"),
-    ("gradle-kts", ".gradle,build@build.gradle.kts"),
+    ("gradle", ".gradle,build@build.gradle,build.gradle.kts"),
     ("cmake", "build@CMakeLists.txt"),
     ("composer", "vendor@composer.json"),
     ("swift", ".build,.swiftpm@Package.swift"),


### PR DESCRIPTION
```diff
- <target[,target...]>[@flag]
+ <target[,target...]>[@detect[,detect...]]
```
Now we can merge `.gradle,build@build.gradle` and `.gradle,build@build.gradle.kts` into one rule `.gradle,build@build.gradle,build.gradle.kts`.